### PR TITLE
Simplify API and support masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ class App extends Component {
 
 | Prop | Type | Default | Definition |
 | --- | --- | --- | --- |
-| speed | number | `3000` | The speed that the words change (in ms) |
+| speed | number | `3000` | The speed that the words change (in ms). Set to 0 to stop animation. |
 | adjustingSpeed | number | `150` | The speed that the container around each word adjusts to the next one (in ms) |
-| initialWidth | number | `0` | If you want to manually adjust the initial width of the word container |
-| initialHeight | number | `0` | If you want to manually adjust the initial height of the word container |
+| fade | boolean | `true` | Enable or disable the fade animation on enter and leave |
+| mask | boolean | `false` | Mask the animation around the bounding box of the animated content |
 | springConfig | object | `{ stiffness: 340, damping: 30 }` | Configuration for [react-motion spring](https://github.com/chenglou/react-motion#--spring-val-number-config-springhelperconfig--opaqueconfig) |
-| style | object \|\| array |  | Any additional styles you might want to send to the wrapper. Uses glamor to process it so you can send either objects or arrays. |
+| style | object or array |  | Any additional styles you might want to send to the wrapper. Uses glamor to process it so you can send either objects or arrays. |
 | children | node | | The words you want to loop (required) |
 
 ### Caveats

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "react-dom": "^15.0.1"
   },
   "dependencies": {
-    "glamor": "^2.20.24",
-    "react-motion": "^0.4.7"
+    "glamor": "^2.20.25",
+    "prop-types": "^15.5.10",
+    "react-motion": "^0.5.0"
   }
 }

--- a/src/components/TextLoop.jsx
+++ b/src/components/TextLoop.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TransitionMotion, spring } from "react-motion";
 import { css } from "glamor";
+import PropTypes from "prop-types";
 
 const defaultDimension = "auto";
 
@@ -202,13 +203,13 @@ class TextLoop extends React.PureComponent {
 }
 
 TextLoop.propTypes = {
-    speed: React.PropTypes.number.isRequired,
-    adjustingSpeed: React.PropTypes.number.isRequired,
-    style: React.PropTypes.object,
-    springConfig: React.PropTypes.object.isRequired,
-    children: React.PropTypes.node.isRequired,
-    fade: React.PropTypes.bool.isRequired,
-    mask: React.PropTypes.bool.isRequired,
+    speed: PropTypes.number.isRequired,
+    adjustingSpeed: PropTypes.number.isRequired,
+    style: PropTypes.object,
+    springConfig: PropTypes.object.isRequired,
+    children: PropTypes.node.isRequired,
+    fade: PropTypes.bool.isRequired,
+    mask: PropTypes.bool.isRequired,
 };
 
 TextLoop.defaultProps = {

--- a/src/components/TextLoop.jsx
+++ b/src/components/TextLoop.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import { TransitionMotion, spring } from "react-motion";
 import { css } from "glamor";
 
+const defaultDimension = "auto";
+
 class TextLoop extends React.PureComponent {
     constructor(props) {
         super(props);
@@ -9,61 +11,81 @@ class TextLoop extends React.PureComponent {
         this.state = {
             currentWord: 0,
             wordCount: 0,
-            width: props.initialWidth,
-            height: props.initialHeight,
+            hasLoaded: false,
         };
     }
 
     componentDidMount() {
-        this.setDefaultWidth();
-        this.tickInterval = setInterval(this.tick, this.props.speed);
+        // Starts animation
+        const { speed } = this.props;
+        if (speed > 0) {
+            this.tick();
+            this.tickInterval = setInterval(this.tick, this.props.speed);
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        const { speed } = this.props;
+        if (prevProps.speed !== speed) {
+            clearInterval(this.tickInterval);
+            if (speed > 0) {
+                this.tickInterval = setInterval(this.tick, speed);
+            }
+        }
     }
 
     componentWillUnmount() {
-        clearInterval(this.tickInterval);
+        if (this.tickInterval != null) {
+            clearInterval(this.tickInterval);
+        }
     }
 
+    // Fade out animation
     willLeave = () => {
         const { height } = this.getDimensions();
 
         return {
-            opacity: spring(0),
-            translate: spring(-height),
+            opacity: spring(this.getOpacity(), this.props.springConfig),
+            translate: spring(-height, this.props.springConfig),
         };
     };
 
+    // Fade in animation
     willEnter = () => {
         const { height } = this.getDimensions();
 
         return {
-            opacity: 0,
+            opacity: this.getOpacity(),
             translate: height,
         };
-    }
-
-    setDefaultWidth() {
-        const { height, width } = this.getDimensions();
-
-        this.setState(() => {
-            return {
-                width,
-                height,
-            };
-        });
-    }
+    };
 
     tick = () => {
         this.setState((state, props) => {
+            if (!state.hasLoaded) {
+                return {
+                    hasLoaded: true,
+                };
+            }
+
             return {
-                currentWord: (state.currentWord + 1) % React.Children.count(props.children),
-                wordCount: (state.wordCount + 1) % 1000, // just a safe value to avoid infinite counts
+                currentWord: (state.currentWord + 1) %
+                    React.Children.count(props.children),
+                wordCount: (state.wordCount + 1) % 1000, // just a safe value to avoid infinite counts,
             };
         });
     };
 
+    getOpacity() {
+        return this.props.fade ? 0 : 1;
+    }
+
     getDimensions() {
         if (this.wordBox == null) {
-            return this.state;
+            return {
+                width: defaultDimension,
+                height: defaultDimension,
+            };
         }
 
         return this.wordBox.getBoundingClientRect();
@@ -71,24 +93,27 @@ class TextLoop extends React.PureComponent {
 
     getStyles() {
         const { height } = this.getDimensions();
+
         return css(
             this.props.style,
+            this.props.mask && { overflow: "hidden" },
             {
                 display: "inline-block",
                 position: "relative",
                 verticalAlign: "top",
                 height,
-            },
+            }
         );
     }
 
-    getTextStyles() {
+    getTextStyles(isStatic) {
+        const position = isStatic ? "relative" : "absolute";
         return css({
             whiteSpace: "nowrap",
             display: "inline-block",
-            position: "absolute",
             left: 0,
             top: 0,
+            position,
         });
     }
 
@@ -99,7 +124,7 @@ class TextLoop extends React.PureComponent {
 
         return [
             {
-                key: `step${wordCount}`,
+                key: `step-${wordCount}`,
                 data: {
                     text: options[currentWord],
                 },
@@ -111,58 +136,66 @@ class TextLoop extends React.PureComponent {
         ];
     }
 
-    render() {
-        // Show first child while it's loading
-        if (this.state.width === 0) {
-            const children = React.Children.toArray(this.props.children)[0];
-            return (
-                <span ref={(n) => { this.wordBox = n; }}>
-                    {children}
-                </span>
-            );
-        }
-
+    renderStatic() {
+        const children = React.Children.toArray(this.props.children)[0];
         return (
-            <div {...this.getStyles()}>
-                <TransitionMotion
-                    willLeave={this.willLeave}
-                    willEnter={this.willEnter}
-                    styles={this.getTransitionMotionStyles()}
-                >
-                    {
-                        (interpolatedStyles) => {
-                            const { height, width } = this.getDimensions();
+            <span
+                ref={(n) => {
+                    this.wordBox = n;
+                }}
+            >
+                {children}
+            </span>
+        );
+    }
 
-                            return (
+    renderAnimation() {
+        return (
+            <TransitionMotion
+                willLeave={this.willLeave}
+                willEnter={this.willEnter}
+                styles={this.getTransitionMotionStyles()}
+            >
+                {(interpolatedStyles) => {
+                    const { height, width } = this.getDimensions();
+                    return (
+                        <div
+                            style={{
+                                transition: `width ${this.props.adjustingSpeed}ms linear`,
+                                height,
+                                width,
+                            }}
+                        >
+                            {interpolatedStyles.map((config) => (
                                 <div
+                                    {...this.getTextStyles(
+                                        width === defaultDimension
+                                    )}
+                                    ref={(n) => {
+                                        this.wordBox = n;
+                                    }}
+                                    key={config.key}
                                     style={{
-                                        transition: `width ${this.props.adjustingSpeed}ms linear`,
-                                        height,
-                                        width,
+                                        opacity: config.style.opacity,
+                                        transform: `translateY(${config.style.translate}px)`,
                                     }}
                                 >
-                                    {
-                                        interpolatedStyles.map(
-                                            (config) => (
-                                                <div
-                                                    {...this.getTextStyles()}
-                                                    ref={(n) => { this.wordBox = n; }}
-                                                    key={config.key}
-                                                    style={{
-                                                        opacity: config.style.opacity,
-                                                        transform: `translateY(${config.style.translate}px)`,
-                                                    }}
-                                                >
-                                                    {config.data.text}
-                                                </div>
-                                            )
-                                        )
-                                    }
+                                    {config.data.text}
                                 </div>
-                            );
-                        }
-                    }
-                </TransitionMotion>
+                            ))}
+                        </div>
+                    );
+                }}
+            </TransitionMotion>
+        );
+    }
+
+    render() {
+        return (
+            <div {...this.getStyles()}>
+                {!this.state.hasLoaded ?
+                    this.renderStatic() :
+                    this.renderAnimation()}
             </div>
         );
     }
@@ -171,19 +204,19 @@ class TextLoop extends React.PureComponent {
 TextLoop.propTypes = {
     speed: React.PropTypes.number.isRequired,
     adjustingSpeed: React.PropTypes.number.isRequired,
-    initialWidth: React.PropTypes.number.isRequired,
-    initialHeight: React.PropTypes.number.isRequired,
     style: React.PropTypes.object,
     springConfig: React.PropTypes.object.isRequired,
     children: React.PropTypes.node.isRequired,
+    fade: React.PropTypes.bool.isRequired,
+    mask: React.PropTypes.bool.isRequired,
 };
 
 TextLoop.defaultProps = {
     speed: 3000,
     adjustingSpeed: 150,
     springConfig: { stiffness: 340, damping: 30 },
-    initialWidth: 0,
-    initialHeight: 0,
+    fade: true,
+    mask: false,
 };
 
 export default TextLoop;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,7 +1343,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.4, fbjs@^0.8.8:
+fbjs@^0.8.4, fbjs@^0.8.8, fbjs@^0.8.9:
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.11.tgz#340b590b8a2278a01ef7467c07a16da9b753db24"
   dependencies:
@@ -1490,13 +1490,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glamor@^2.20.24:
-  version "2.20.24"
-  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.24.tgz#a299af2eec687322634ba38e4a0854d8743d2041"
+glamor@^2.20.25:
+  version "2.20.25"
+  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.25.tgz#71b84b82b67a9327771ac59de53ee915d148a4a3"
   dependencies:
     babel-runtime "^6.18.0"
     fbjs "^0.8.8"
     object-assign "^4.1.0"
+    prop-types "^15.5.8"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -1892,7 +1893,7 @@ lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2169,6 +2170,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10, prop-types@^15.5.8:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2199,11 +2207,12 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-motion@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.4.7.tgz#f77331ec7920bdb0d0cfc37eb6ffa10571bf42c7"
+react-motion@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.0.tgz#1708fc2aee552900d21c1e6bed28346863e017b6"
   dependencies:
     performance-now "^0.2.0"
+    prop-types "^15.5.8"
     raf "^3.1.0"
 
 react@^15.4.2:


### PR DESCRIPTION
This simplifies the API and adds support for masking the animation around the bounding box.

![text-loop-masked](https://cloud.githubusercontent.com/assets/38172/26645314/819cf646-462f-11e7-99de-1bfcb80c2dcc.gif)

Initial width/height are no longer needed as we have an improved way of dealing with the first render that gets the correct dimensions.

Fixes #6 

